### PR TITLE
Corrige links de imagens na documentação antiga

### DIFF
--- a/docs/doc-antiga/home/Arquitetura 9c8bf5a2d8164bb197c759d8ef470ad5.md
+++ b/docs/doc-antiga/home/Arquitetura 9c8bf5a2d8164bb197c759d8ef470ad5.md
@@ -33,4 +33,4 @@
 
 ## Arquitetura da infraestrutura de extensões
 
-![Quoti Architeture-Extensions Architecture.drawio.png](../assets/Quoti_Architeture-Extensions_Architecture.drawio.png)
+![Quoti Architeture-Extensions Architecture.drawio.png](Quoti_Architeture-Extensions_Architecture.drawio.png)

--- a/docs/doc-antiga/home/Chat e mensageria ce1cf75095c1491ea70ac87a5718a27f/Integração com o Quoti Chat e9842c880108400ca4bacf23d04e09ba.md
+++ b/docs/doc-antiga/home/Chat e mensageria ce1cf75095c1491ea70ac87a5718a27f/Integração com o Quoti Chat e9842c880108400ca4bacf23d04e09ba.md
@@ -13,7 +13,7 @@ Caso você tenha a necessidade de integrar um canal de comunicação (chat) exte
 
 ### Integração com Live Chat externo
 
-![Quoti Chat Integration Flow.drawio.png](Integrac%CC%A7a%CC%83o%20com%20o%20Quoti%20Chat%20e9842c880108400ca4bacf23d04e09ba/Quoti_Chat_Integration_Flow.drawio.png)
+![Quoti Chat Integration Flow.drawio.png](Quoti_Chat_Integration_Flow.drawio.png)
 
 Considerando um cenário em que você possui um *Live Chat* desenvolvido fora da Plataforma Quoti e precisa que as mensagens enviadas através do *Live Chat* por um cliente sejam enviadas para um atendente humano usuário do Quoti Chat, você terá que realizar as seguintes etapas:
 
@@ -79,11 +79,11 @@ Considerando um cenário em que você possui um *Live Chat* desenvolvido fora da
     1. Acesse o site `https://quoti.cloud/{organization}/user`
     2. Clique no botão "+" no canto inferior direito:
         
-        ![Captura de Tela 2022-08-19 às 08.59.50.png](Integrac%CC%A7a%CC%83o%20com%20o%20Quoti%20Chat%20e9842c880108400ca4bacf23d04e09ba/Captura_de_Tela_2022-08-19_as_08.59.50.png)
+        ![Captura de Tela 2022-08-19 às 08.59.50.png](Captura_de_Tela_2022-08-19_as_08.59.50.png)
         
     3. Clique na opção "CRIRAR USUÁRIO":
         
-        ![Captura de Tela 2022-08-19 às 09.00.26.png](Integrac%CC%A7a%CC%83o%20com%20o%20Quoti%20Chat%20e9842c880108400ca4bacf23d04e09ba/Captura_de_Tela_2022-08-19_as_09.00.26.png)
+        ![Captura de Tela 2022-08-19 às 09.00.26.png](Captura_de_Tela_2022-08-19_as_09.00.26.png)
         
     4. Preencha as informações:
         1. Nome: Informe o nome do seu Bot

--- a/docs/doc-antiga/home/Componentes prontos 5cdb82ce62e74e68bf949a5548d1dc06.md
+++ b/docs/doc-antiga/home/Componentes prontos 5cdb82ce62e74e68bf949a5548d1dc06.md
@@ -11,4 +11,4 @@ Para agilizar o seu desenvolvimento, contamos com um *Storybook* de componentes 
 
 Acesse em [https://beta.docs.quoti.dev](https://beta.docs.quoti.dev)
 
-![Captura de Tela 2021-12-09 às 15.33.47.png](Componentes%20prontos%205cdb82ce62e74e68bf949a5548d1dc06/Captura_de_Tela_2021-12-09_as_15.33.47.png)
+![Captura de Tela 2021-12-09 às 15.33.47.png](Captura_de_Tela_2021-12-09_as_15.33.47.png)

--- a/docs/doc-antiga/home/Configuração self-hosted 52a075db318a490f90847fc7b86cb84c/AWS - Amazon 0414f455d77d4fb2b92f661376b68cfb/Banco de dados MySQL d7acc783c0bd4bc0955de2289287712b.md
+++ b/docs/doc-antiga/home/Configuração self-hosted 52a075db318a490f90847fc7b86cb84c/AWS - Amazon 0414f455d77d4fb2b92f661376b68cfb/Banco de dados MySQL d7acc783c0bd4bc0955de2289287712b.md
@@ -18,25 +18,25 @@ Para configurarmos nosso banco de dados em ambiente Amazon, utilizaremos o Amazo
 
 Em serviços encontre RDS
 
-![Untitled](Banco%20de%20dados%20MySQL%20d7acc783c0bd4bc0955de2289287712b/Untitled.png)
+![Untitled](Untitled.png)
 
 Escolha a opção “Create Database” e lembre-se de estar na região de nuvem que você deseja instanciar seu ambiente
 
-![Untitled](Banco%20de%20dados%20MySQL%20d7acc783c0bd4bc0955de2289287712b/Untitled%201.png)
+![Untitled](Untitled%201.png)
 
 Após confirmar que está na região de nuvem que você deseja, selecione “Create database”
 
-![Untitled](Banco%20de%20dados%20MySQL%20d7acc783c0bd4bc0955de2289287712b/Untitled%202.png)
+![Untitled](Untitled%202.png)
 
 Escolha o modo de criação de banco de dados padrão. Além disso, recomendamos utilizar o MySQL 8.0. Porém, também suportamos MySQL 5.7 e MariaDB 10.7
 
-![Untitled](Banco%20de%20dados%20MySQL%20d7acc783c0bd4bc0955de2289287712b/Untitled%203.png)
+![Untitled](Untitled%203.png)
 
 Após escolher a versão e modelo do banco de dados, devemos definir o modelo de instância e também as configurações padrões do usuário root do banco de dados.
 
 Todos os campos de settings podem ser definidos de acordo
 
-![Untitled](Banco%20de%20dados%20MySQL%20d7acc783c0bd4bc0955de2289287712b/Untitled%204.png)
+![Untitled](Untitled%204.png)
 
 Em instance size, recomendamos utilizar as seguintes configurações:
 
@@ -46,8 +46,8 @@ db.t3.medium - 10.0001 a 50.000 usuários diários
 
 db.t3.xlarge - acima de 50.001 usuários diários
 
-![Untitled](Banco%20de%20dados%20MySQL%20d7acc783c0bd4bc0955de2289287712b/Untitled%205.png)
+![Untitled](Untitled%205.png)
 
 Em Storage indicamos alocar 20 GB e manter selecionada a opção de autoscaling.
 
-![Untitled](Banco%20de%20dados%20MySQL%20d7acc783c0bd4bc0955de2289287712b/Untitled%206.png)
+![Untitled](Untitled%206.png)

--- a/docs/doc-antiga/home/Cronjobs c03c5734c44545ce9a118215dbf35ba6.md
+++ b/docs/doc-antiga/home/Cronjobs c03c5734c44545ce9a118215dbf35ba6.md
@@ -19,31 +19,31 @@ Para criar um fluxo baseado em cron:
 1. Acesse `https://quoti.cloud/{organização}/app/workflow`;
 2. No canto superior direito do fluxo criado, clique no botão para adicionar um novo *node* ao seu fluxo:
     
-    ![Captura de Tela 2021-12-11 às 10.24.50.png](Cronjobs%20c03c5734c44545ce9a118215dbf35ba6/Captura_de_Tela_2021-12-11_as_10.24.50.png)
+    ![Captura de Tela 2021-12-11 às 10.24.50.png](Captura_de_Tela_2021-12-11_as_10.24.50.png)
     
 3. Pesquise por `Cron` na caixa de seleção e clique na opção `Cron` encontrada:
     
-    ![Captura de Tela 2021-12-11 às 10.26.25.png](Cronjobs%20c03c5734c44545ce9a118215dbf35ba6/Captura_de_Tela_2021-12-11_as_10.26.25.png)
+    ![Captura de Tela 2021-12-11 às 10.26.25.png](Captura_de_Tela_2021-12-11_as_10.26.25.png)
     
 4. Clique no botão "Add Cron Time": 
     
-    ![Captura de Tela 2021-12-11 às 10.27.35.png](Cronjobs%20c03c5734c44545ce9a118215dbf35ba6/Captura_de_Tela_2021-12-11_as_10.27.35.png)
+    ![Captura de Tela 2021-12-11 às 10.27.35.png](Captura_de_Tela_2021-12-11_as_10.27.35.png)
     
 5. Em "Mode", escolha o modo de execução do seu seu Cron (a cada minuto, hora, dia, semana, mês ou [customizado](https://receitasdecodigo.com.br/java/o-basico-sobre-cron-expression)): 
     
-    ![Captura de Tela 2021-12-11 às 10.29.43.png](Cronjobs%20c03c5734c44545ce9a118215dbf35ba6/Captura_de_Tela_2021-12-11_as_10.29.43.png)
+    ![Captura de Tela 2021-12-11 às 10.29.43.png](Captura_de_Tela_2021-12-11_as_10.29.43.png)
     
 6. Após finalizar a configuração do seu Cron, clique no X para fechar o popup de edição do *node*:
     
-    ![Captura de Tela 2021-12-11 às 10.31.18.png](Cronjobs%20c03c5734c44545ce9a118215dbf35ba6/Captura_de_Tela_2021-12-11_as_10.31.18.png)
+    ![Captura de Tela 2021-12-11 às 10.31.18.png](Captura_de_Tela_2021-12-11_as_10.31.18.png)
     
 7. Adicione novos *nodes* para serem executados após o *node* do Cron, por exemplo: 
     
-    ![Captura de Tela 2021-12-11 às 10.34.39.png](Cronjobs%20c03c5734c44545ce9a118215dbf35ba6/Captura_de_Tela_2021-12-11_as_10.34.39.png)
+    ![Captura de Tela 2021-12-11 às 10.34.39.png](Captura_de_Tela_2021-12-11_as_10.34.39.png)
     
 8. Para ativar seu Cron, clique no botão "Save" e depois em "Active" no canto superior direito:
     
-    ![Captura de Tela 2021-12-11 às 10.36.43.png](Cronjobs%20c03c5734c44545ce9a118215dbf35ba6/Captura_de_Tela_2021-12-11_as_10.36.43.png)
+    ![Captura de Tela 2021-12-11 às 10.36.43.png](Captura_de_Tela_2021-12-11_as_10.36.43.png)
     
 
 - Um exemplo para você copiar e colar no seu fluxo, que realiza uma verificação na [API de formulários](Criador%20de%20formula%CC%81rios%20ae4d18b95c37490f953070bea5837210.md) do Quoti todos os dias às 14:00 :

--- a/docs/doc-antiga/home/Gestão de Menus de8dfc6b3e1c4feba06519fc941a9d91.md
+++ b/docs/doc-antiga/home/Gestão de Menus de8dfc6b3e1c4feba06519fc941a9d91.md
@@ -15,7 +15,7 @@ Se você não estiver visualizando um menu, adicione itens ao menu e [confira as
 
 ## Menu Lateral
 
-![Captura de Tela 2021-12-10 às 08.32.25.png](Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_08.32.25.png)
+![Captura de Tela 2021-12-10 às 08.32.25.png](Captura_de_Tela_2021-12-10_as_08.32.25.png)
 
 - **Adicionando itens ao menu**
     
@@ -24,59 +24,59 @@ Se você não estiver visualizando um menu, adicione itens ao menu e [confira as
     
     1. Em "Selecione o tipo de menu", escolha a opção `Menu lateral`;
         
-        ![Captura de Tela 2021-12-10 às 08.39.54.png](Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_08.39.54.png)
+    ![Captura de Tela 2021-12-10 às 08.39.54.png](Captura_de_Tela_2021-12-10_as_08.39.54.png)
         
     
     1. Em "Selecione o perfil de usuário", escolha o perfil de usuário que você deseja ajustar;
         
-        ![Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_08.40.16.png](Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_08.40.16.png)
+    ![Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_08.40.16.png](Captura_de_Tela_2021-12-10_as_08.40.16.png)
         
     2. Clique no botão "Nova página", logo abaixo dos filtros;
         
-        ![Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_08.41.38.png](Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_08.41.38.png)
+        ![Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_08.41.38.png](Captura_de_Tela_2021-12-10_as_08.41.38.png)
         
     3. Um novo item foi criado. Para editá-lo, clique no botão de editar;
         
-        ![Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_08.44.23.png](Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_08.44.23.png)
+    ![Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_08.44.23.png](Captura_de_Tela_2021-12-10_as_08.44.23.png)
         
     4. Preencha o "Nome do menu" e escolha um ícone para o Menu;
         
-        ![Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_08.45.31.png](Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_08.45.31.png)
+    ![Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_08.45.31.png](Captura_de_Tela_2021-12-10_as_08.45.31.png)
         
     5. Um item de menu pode desempenhar diferentes ações:
-        1. Caso queira levar o usuário para uma extensão:
-            1. Selecione a opção "Página" e em "Página do item de Menu" escolha a sua extensão
-                
-                ![Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_08.49.32.png](Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_08.49.32.png)
-                
-        2. Caso queira exibir uma página externa à plataforma dentro de um `iframe` na plataforma:
-            1. Selecione a opção "URL" e em "URL Externa" coloque o link completo para a sua página externa.
-                
-                ![Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_08.55.26.png](Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_08.55.26.png)
-                
-        3. Caso queira abrir uma página externa à plataforma em uma nova aba:
-            1. Selecione a opção "URL" e em "URL Externa" coloque o link completo para a sua página externa e selecione a opção "Abrir em nova guia".
-                
-                ![Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_08.57.44.png](Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_08.57.44.png)
+    5.1. Caso queira levar o usuário para uma extensão:
+        1. Selecione a opção "Página" e em "Página do item de Menu" escolha a sua extensão
+            
+    ![Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_08.49.32.png](Captura_de_Tela_2021-12-10_as_08.49.32.png)
+            
+    5.2. Caso queira exibir uma página externa à plataforma dentro de um `iframe` na plataforma:
+        1. Selecione a opção "URL" e em "URL Externa" coloque o link completo para a sua página externa.
+            
+    ![Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_08.55.26.png](Captura_de_Tela_2021-12-10_as_08.55.26.png)
+            
+    5.3. Caso queira abrir uma página externa à plataforma em uma nova aba:
+        1. Selecione a opção "URL" e em "URL Externa" coloque o link completo para a sua página externa e selecione a opção "Abrir em nova guia".
+            
+    ![Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_08.57.44.png](Captura_de_Tela_2021-12-10_as_08.57.44.png)
                 
     6. Ao finalizar todas as adições, clique no botão "Salvar alterações"
         
-        ![Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_08.59.48.png](Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_08.59.48.png)
+    ![Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_08.59.48.png](Captura_de_Tela_2021-12-10_as_08.59.48.png)
         
 - **Removendo itens do menu**
     
     
     1. Em "Selecione o perfil de usuário", escolha o perfil de usuário que você deseja ajustar;
         
-        ![Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_08.40.16.png](Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_08.40.16.png)
+    ![Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_08.40.16.png](Captura_de_Tela_2021-12-10_as_08.40.16.png)
         
     2. Encontre o item que você deseja excluir e clique no ícone de excluir:
         
-        ![Captura de Tela 2021-12-10 às 19.02.54.png](Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_19.02.54.png)
+    ![Captura de Tela 2021-12-10 às 19.02.54.png](Captura_de_Tela_2021-12-10_as_19.02.54.png)
         
     3. Ao finalizar todas as exclusões, clique no botão "Salvar alterações":
         
-        ![Captura de Tela 2021-12-10 às 19.09.51.png](Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_19.09.51.png)
+    ![Captura de Tela 2021-12-10 às 19.09.51.png](Captura_de_Tela_2021-12-10_as_19.09.51.png)
         
     
 - **Reordenando itens do menu**
@@ -84,77 +84,77 @@ Se você não estiver visualizando um menu, adicione itens ao menu e [confira as
     
     1. Em "Selecione o perfil de usuário", escolha o perfil de usuário que você deseja ajustar;
         
-        ![Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_08.40.16.png](Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_08.40.16.png)
+    ![Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_08.40.16.png](Captura_de_Tela_2021-12-10_as_08.40.16.png)
         
     2. Encontre o item que você deseja mudar a ordem e:
         1. Clique e segure no icone de reordenar:
             
-            ![Captura de Tela 2021-12-10 às 19.17.18.png](Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_19.17.18.png)
+        ![Captura de Tela 2021-12-10 às 19.17.18.png](Captura_de_Tela_2021-12-10_as_19.17.18.png)
             
         2. Arraste para a posição desejada:
             
-            ![Gravacao-de-Tela-2021-12-10-as-1.gif](Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Gravacao-de-Tela-2021-12-10-as-1.gif)
+        ![Gravacao-de-Tela-2021-12-10-as-1.gif](Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Gravacao-de-Tela-2021-12-10-as-1.gif)
             
     3. Ao finalizar todas as exclusões, clique no botão "Salvar alterações":
         
-        ![Captura de Tela 2021-12-10 às 19.09.51.png](Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_19.09.51.png)
+    ![Captura de Tela 2021-12-10 às 19.09.51.png](Captura_de_Tela_2021-12-10_as_19.09.51.png)
         
 - **Adicionando sub-menu (agrupamento de itens do menu)**
     
     
     1. Em "Selecione o perfil de usuário", escolha o perfil de usuário que você deseja ajustar;
         
-        ![Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_08.40.16.png](Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_08.40.16.png)
+    ![Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_08.40.16.png](Captura_de_Tela_2021-12-10_as_08.40.16.png)
         
     2. Selecione a opção "Nova categoria":
         
-        ![Captura de Tela 2021-12-10 às 19.31.33.png](Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_19.31.33.png)
+    ![Captura de Tela 2021-12-10 às 19.31.33.png](Captura_de_Tela_2021-12-10_as_19.31.33.png)
         
     3. A nova categoria será criada no começo da lista. Clique no ícone de editar:
         
-        ![Captura de Tela 2021-12-10 às 19.32.37.png](Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_19.32.37.png)
+    ![Captura de Tela 2021-12-10 às 19.32.37.png](Captura_de_Tela_2021-12-10_as_19.32.37.png)
         
     4. Defina o "Nome do menu" e o "Ícone do menu" em que os itens de menu ficarão agrupados:
         
-        ![Captura de Tela 2021-12-10 às 19.34.04.png](Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_19.34.04.png)
+    ![Captura de Tela 2021-12-10 às 19.34.04.png](Captura_de_Tela_2021-12-10_as_19.34.04.png)
         
     5. Para adicionar itens de menu à essa categoria, clique no botão "Nova página":
         
-        ![Captura de Tela 2021-12-10 às 19.36.40.png](Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_19.36.40.png)
+    ![Captura de Tela 2021-12-10 às 19.36.40.png](Captura_de_Tela_2021-12-10_as_19.36.40.png)
         
     6. Um novo item foi criado na categoria. Para editá-lo, clique no botão de editar;
         
-        ![Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_08.44.23.png](Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_08.44.23.png)
+    ![Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_08.44.23.png](Captura_de_Tela_2021-12-10_as_08.44.23.png)
         
     7. Preencha o "Nome do menu" e escolha um ícone para o Menu;
         
-        ![Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_08.45.31.png](Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_08.45.31.png)
+    ![Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_08.45.31.png](Captura_de_Tela_2021-12-10_as_08.45.31.png)
         
     8. Um item de menu pode desempenhar diferentes ações:
         1. Caso queira levar o usuário para uma extensão:
             1. Selecione a opção "Página" e em "Página do item de Menu" escolha a sua extensão
                 
-                ![Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_08.49.32.png](Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_08.49.32.png)
+            ![Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_08.49.32.png](Captura_de_Tela_2021-12-10_as_08.49.32.png)
                 
         2. Caso queira exibir uma página externa à plataforma dentro de um `iframe` na plataforma:
             1. Selecione a opção "URL" e em "URL Externa" coloque o link completo para a sua página externa.
                 
-                ![Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_08.55.26.png](Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_08.55.26.png)
+            ![Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_08.55.26.png](Captura_de_Tela_2021-12-10_as_08.55.26.png)
                 
         3. Caso queira abrir uma página externa à plataforma em uma nova aba:
             1. Selecione a opção "URL" e em "URL Externa" coloque o link completo para a sua página externa e selecione a opção "Abrir em nova guia".
                 
-                ![Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_08.57.44.png](Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_08.57.44.png)
+            ![Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_08.57.44.png](Captura_de_Tela_2021-12-10_as_08.57.44.png)
                 
     9. Após adicionar todos os itens de menu à sua categoria, clique no botão "Salvar alterações"
         
-        ![Captura de Tela 2021-12-10 às 19.35.30.png](Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_19.35.30.png)
+    ![Captura de Tela 2021-12-10 às 19.35.30.png](Captura_de_Tela_2021-12-10_as_19.35.30.png)
         
     
 
 ## Menu Superior
 
-![Captura de Tela 2021-12-10 às 18.46.05.png](Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_18.46.05.png)
+![Captura de Tela 2021-12-10 às 18.46.05.png](Captura_de_Tela_2021-12-10_as_18.46.05.png)
 
 
 💡 O menu superior sempre é exibido mesmo que não tenha itens associados à ele. Atualmente, só é possível [desativar o menu superior dentro de uma extensão.](Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91.md)
@@ -166,7 +166,7 @@ Se você não estiver visualizando um menu, adicione itens ao menu e [confira as
     
     1. Em "Selecione o tipo de menu", escolha a opção `Menu superior`;
         
-        ![Captura de Tela 2021-12-10 às 09.08.55.png](Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_09.08.55.png)
+    ![Captura de Tela 2021-12-10 às 09.08.55.png](Captura_de_Tela_2021-12-10_as_09.08.55.png)
         
 - **Removendo itens do menu**
     
@@ -190,7 +190,7 @@ Se você não estiver visualizando um menu, adicione itens ao menu e [confira as
     
     1. Em "Selecione o tipo de menu", escolha a opção `Menu inferior`;
         
-        ![Captura de Tela 2021-12-10 às 09.11.17.png](Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_09.11.17.png)
+    ![Captura de Tela 2021-12-10 às 09.11.17.png](Captura_de_Tela_2021-12-10_as_09.11.17.png)
         
 - **Removendo itens do menu**
     
@@ -202,7 +202,7 @@ Se você não estiver visualizando um menu, adicione itens ao menu e [confira as
 
 ## Atalhos
 
-![Captura de Tela 2021-12-10 às 09.20.46.png](Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_09.20.46.png)
+![Captura de Tela 2021-12-10 às 09.20.46.png](Captura_de_Tela_2021-12-10_as_09.20.46.png)
 
 
 💡 Atualmente os atalhos são universais para a aplicação. É possível ativar ou desativar o botão de acesso aos atalhos por perfil, mas não é possível atribuir atalhos específicos por perfil.
@@ -213,19 +213,19 @@ Se você não estiver visualizando um menu, adicione itens ao menu e [confira as
     1. Acesse `https://quoti.cloud/{organização}/shortcuts`;
     2. No canto inferior direito, clique no botão `+` :
         
-        ![Captura de Tela 2021-12-10 às 09.24.09.png](Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_09.24.09.png)
+    ![Captura de Tela 2021-12-10 às 09.24.09.png](Captura_de_Tela_2021-12-10_as_09.24.09.png)
         
     3. Defina o "Nome" do seu atalho:
         
-        ![Captura de Tela 2021-12-10 às 09.27.44.png](Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_09.27.44.png)
+    ![Captura de Tela 2021-12-10 às 09.27.44.png](Captura_de_Tela_2021-12-10_as_09.27.44.png)
         
     4. Escolha um "Ícone" para o seu atalho, a lista completa de ícones encontra-se em [Material Design Icons](https://materialdesignicons.com/) :
         
-        ![Captura de Tela 2021-12-10 às 09.28.21.png](Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_09.28.21.png)
+    ![Captura de Tela 2021-12-10 às 09.28.21.png](Captura_de_Tela_2021-12-10_as_09.28.21.png)
         
     5. Clique em "Cadastrar Shortcut":
         
-        ![Captura de Tela 2021-12-10 às 09.29.59.png](Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_09.29.59.png)
+    ![Captura de Tela 2021-12-10 às 09.29.59.png](Captura_de_Tela_2021-12-10_as_09.29.59.png)
         
 
 ## Troubleshooting
@@ -244,15 +244,15 @@ Se você não estiver visualizando um menu, adicione itens ao menu e [confira as
             1. Se a permissão não existir, crie uma nova permissão com esse conteúdo
     3. Clique no ícone de editar ✏️ da permissão escolhida:
         
-        ![Captura de Tela 2021-12-10 às 08.14.49.png](Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_08.14.49.png)
+    ![Captura de Tela 2021-12-10 às 08.14.49.png](Captura_de_Tela_2021-12-10_as_08.14.49.png)
         
     4. Na opção "Perfis de usuário que possuem essa permissão", selecione todos os perfis de usuário que você deseja que visualizem o menu escolhido.
         
-        ![Captura de Tela 2021-12-10 às 08.18.13.png](Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_08.18.13.png)
+    ![Captura de Tela 2021-12-10 às 08.18.13.png](Captura_de_Tela_2021-12-10_as_08.18.13.png)
         
     5. Clique no botão "Salvar permissão"
         
-        ![Captura de Tela 2021-12-10 às 08.24.42.png](Gesta%CC%83o%20de%20Menus%20de8dfc6b3e1c4feba06519fc941a9d91/Captura_de_Tela_2021-12-10_as_08.24.42.png)
+    ![Captura de Tela 2021-12-10 às 08.24.42.png](Captura_de_Tela_2021-12-10_as_08.24.42.png)
         
 - Como desabilitar o menu superior?
     

--- a/docs/doc-antiga/home/Usuários ba51d1f715ba48288773d461f9001c3e.md
+++ b/docs/doc-antiga/home/Usuários ba51d1f715ba48288773d461f9001c3e.md
@@ -14,9 +14,9 @@
 
 ## Definições
 
-![Untitled](Usua%CC%81rios%20ba51d1f715ba48288773d461f9001c3e/Untitled.png)
+![Untitled](Untitled.png)
 
-![Untitled](Usua%CC%81rios%20ba51d1f715ba48288773d461f9001c3e/Untitled%201.png)
+![Untitled](Untitled%201.png)
 
 Ao clicar em um usuário específico temos 4 abas de informações:
 
@@ -41,39 +41,39 @@ Ao clicar em um usuário específico temos 4 abas de informações:
     
     Para criar um usuário, use o botão (+) no canto inferior direito da página de gestão de usuários.
     
-    ![Untitled](Usua%CC%81rios%20ba51d1f715ba48288773d461f9001c3e/Untitled%202.png)
+    ![Untitled](Untitled%202.png)
     
     Isso trará duas opções: "Criar usuário" ou "Criar em lote". Como o objetivo desse tutorial é criar um usuário, selecione "Criar usuário”
     
-    ![Untitled](Usua%CC%81rios%20ba51d1f715ba48288773d461f9001c3e/Untitled%203.png)
+    ![Untitled](Untitled%203.png)
     
     O Quoti abrirá uma caixinha com um formulário para preencher os dados do usuário a ser criado.
     
-    ![Untitled](Usua%CC%81rios%20ba51d1f715ba48288773d461f9001c3e/Untitled%204.png)
+    ![Untitled](Untitled%204.png)
     
     Agora é só preencher todas as informações, foto, grupos (se precisar) e relacionamentos (se precisar). Um usuário precisa, obrigatoriamente, ter um nome com sobrenome, email, login e um perfil.
     
     Uma vez que os campos obrigatórios estão preenchidos, só resta clicar em Criar para proceder com a criação do usuário.
     
-    ![Untitled](Usua%CC%81rios%20ba51d1f715ba48288773d461f9001c3e/Untitled%205.png)
+    ![Untitled](Untitled%205.png)
     
     Pronto! Usuário criado com sucesso!
     
-    ![Untitled](Usua%CC%81rios%20ba51d1f715ba48288773d461f9001c3e/Untitled%206.png)
+    ![Untitled](Untitled%206.png)
     
 - Como editar o email de um usuário?
     
     Procure o usuário que deseja editar o email dentro da página de gestão de usuários e clique nele para abrir a caixinha de edição.
     
-    ![Untitled](Usua%CC%81rios%20ba51d1f715ba48288773d461f9001c3e/Untitled%207.png)
+    ![Untitled](Untitled%207.png)
     
     Para editar o email, ache o campo "email do usuário" e altere para o novo email.
     
-    ![Untitled](Usua%CC%81rios%20ba51d1f715ba48288773d461f9001c3e/Untitled%208.png)
+    ![Untitled](Untitled%208.png)
     
     Uma vez que definiu o novo email, para salvar é só clicar no botão "Salvar" do canto inferior direito.
     
-    ![Untitled](Usua%CC%81rios%20ba51d1f715ba48288773d461f9001c3e/Untitled%209.png)
+    ![Untitled](Untitled%209.png)
     
     Pronto! Email do usuário editado.
     
@@ -81,7 +81,7 @@ Ao clicar em um usuário específico temos 4 abas de informações:
     
     Como essa documentação mostrou anteriormente, o campo usuário registrado representa pro Quoti se o usuário já criou sua senha anteriormente. Para resetar a senha de qualquer usuário, basta desativar o campo usuário registrado.
     
-    ![Untitled](Usua%CC%81rios%20ba51d1f715ba48288773d461f9001c3e/Untitled%2010.png)
+    ![Untitled](Untitled%2010.png)
     
     Lembrando que após alterar qualquer campo nessa caixinha, é preciso salvar as alterações para refletir na aplicação. Você pode fazer isso através do botão salvar no canto inferior direito.
     

--- a/docs/doc-antiga/home/Versionamento de extensões 94718b18bfb74830bc9f37326774dce3.md
+++ b/docs/doc-antiga/home/Versionamento de extensões 94718b18bfb74830bc9f37326774dce3.md
@@ -21,7 +21,7 @@
     
     1. Encontre, na lista, a extensão que você deseja e clique no ícone de editar:
         
-        ![Captura de Tela 2021-12-11 às 08.13.47.png](Versionamento%20de%20extenso%CC%83es%2094718b18bfb74830bc9f37326774dce3/Captura_de_Tela_2021-12-11_as_08.13.47.png)
+        ![Captura de Tela 2021-12-11 às 08.13.47.png](Captura_de_Tela_2021-12-11_as_08.13.47.png)
         
     1. Em "Versões anteriores", você irá encontrar todas as versões de uma extensão:
         
@@ -34,7 +34,7 @@
         
     2. Digite o novo nome da versão e clique no botão `ENTER` do seu teclado:
         
-        ![Captura de Tela 2021-12-11 às 08.45.40.png](Versionamento%20de%20extenso%CC%83es%2094718b18bfb74830bc9f37326774dce3/Captura_de_Tela_2021-12-11_as_08.45.40.png)
+        ![Captura de Tela 2021-12-11 às 08.45.40.png](Captura_de_Tela_2021-12-11_as_08.45.40.png)
         
     3. A versão da sua extensão foi renomeada. Você pode fechar o popup de edição da extensão.
     
@@ -74,15 +74,15 @@
     
     1. Em "Versões anteriores", localize a versão que você deseja e clique no ícone de "Baixar":
         
-        ![Captura de Tela 2021-12-11 às 08.16.27.png](Versionamento%20de%20extenso%CC%83es%2094718b18bfb74830bc9f37326774dce3/Captura_de_Tela_2021-12-11_as_08.16.27.png)
+        ![Captura de Tela 2021-12-11 às 08.16.27.png](Captura_de_Tela_2021-12-11_as_08.16.27.png)
         
     2. Feche o popup de edição da extensão
         
-        ![Captura de Tela 2021-12-11 às 08.19.53.png](Versionamento%20de%20extenso%CC%83es%2094718b18bfb74830bc9f37326774dce3/Captura_de_Tela_2021-12-11_as_08.19.53.png)
+        ![Captura de Tela 2021-12-11 às 08.19.53.png](Captura_de_Tela_2021-12-11_as_08.19.53.png)
         
     3. No canto inferior direito, clique no botão para criar uma nova extensão:
         
-        ![Captura de Tela 2021-12-11 às 08.21.09.png](Versionamento%20de%20extenso%CC%83es%2094718b18bfb74830bc9f37326774dce3/Captura_de_Tela_2021-12-11_as_08.21.09.png)
+        ![Captura de Tela 2021-12-11 às 08.21.09.png](Captura_de_Tela_2021-12-11_as_08.21.09.png)
         
     4. Defina o "Título" e o "Tipo da sua extensão":
         
@@ -90,16 +90,16 @@
         1. A opção **Sem build** possibilita o uso de um único arquivo para carregar toda sua extensão.
         2. A opção **Com build** permite que o usuário crie sua extensão como se fosse um projeto, ou seja, sua extensão pode ter componentes em arquivos separados, dependências extras que ficam em um *package.json*, etc. Nessa opção, um *build* da extensão é feito antes de enviar o código dela para o Quoti.
         
-        ![Captura de Tela 2021-12-11 às 08.24.35.png](Versionamento%20de%20extenso%CC%83es%2094718b18bfb74830bc9f37326774dce3/Captura_de_Tela_2021-12-11_as_08.24.35.png)
+        ![Captura de Tela 2021-12-11 às 08.24.35.png](Captura_de_Tela_2021-12-11_as_08.24.35.png)
         
     5. No campo "Área de upload" arraste ou selecione o arquivo baixado no [passo 3](Versionamento%20de%20extenso%CC%83es%2094718b18bfb74830bc9f37326774dce3.md):
         
-        ![Captura de Tela 2021-12-11 às 08.30.40.png](Versionamento%20de%20extenso%CC%83es%2094718b18bfb74830bc9f37326774dce3/Captura_de_Tela_2021-12-11_as_08.30.40.png)
+        ![Captura de Tela 2021-12-11 às 08.30.40.png](Captura_de_Tela_2021-12-11_as_08.30.40.png)
         
     6. Clique no botão "Criar extensão"
         
-        ![Captura de Tela 2021-12-11 às 08.32.53.png](Versionamento%20de%20extenso%CC%83es%2094718b18bfb74830bc9f37326774dce3/Captura_de_Tela_2021-12-11_as_08.32.53.png)
+        ![Captura de Tela 2021-12-11 às 08.32.53.png](Captura_de_Tela_2021-12-11_as_08.32.53.png)
         
     7. Teste a versão na sua nova extensão, clicando no ícone de "Abrir":
         
-        ![Captura de Tela 2021-12-11 às 08.34.42.png](Versionamento%20de%20extenso%CC%83es%2094718b18bfb74830bc9f37326774dce3/Captura_de_Tela_2021-12-11_as_08.34.42.png)
+        ![Captura de Tela 2021-12-11 às 08.34.42.png](Captura_de_Tela_2021-12-11_as_08.34.42.png)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes image links in old documentation by removing unnecessary path segments.
> 
>   - **Image Links**:
>     - Fixes image links in `Arquitetura 9c8bf5a2d8164bb197c759d8ef470ad5.md`, `Componentes prontos 5cdb82ce62e74e68bf949a5548d1dc06.md`, and `Cronjobs c03c5734c44545ce9a118215dbf35ba6.md` by removing unnecessary path segments.
>     - Ensures images are correctly displayed in the old documentation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=byndcloud%2Fquoti-docs&utm_source=github&utm_medium=referral)<sup> for fb0356f0f3f4f33023c4deefc47a5c01a1187f19. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->