### PR TITLE
docs: enhance Quoti webhook documentation with examples and operator …

### DIFF
--- a/docs/quoti-databases/webhooks.md
+++ b/docs/quoti-databases/webhooks.md
@@ -60,10 +60,10 @@ Você pode cadastrar um novo webhook através do botão “+ Novo”
 
 | Tipo              | Operador                                                               | Descrição                                                     |
 |-------------------|------------------------------------------------------------------------|---------------------------------------------------------------|
-| **Booleano**      | `all`, `any`, `not`                                                    | Controlam a lógica de múltiplas                               |
+| **Booleano**      | `all`, `any`, `not`                                                    | Controlam a lógica de múltiplas condições                     |
 | **String/Número** | `equal`, `notEqual`                                                    | Igualdade ou diferença exata (`===` / `!==`)                  |
 | **Numérico**      | `lessThan`, `lessThanInclusive`, `greaterThan`, `greaterThanInclusive` | Comparações numéricas diretas                                 |
-| **Array**         | `in`, `notIn`, `contains`, `doesNotContain`                            | Verifica a presença ou ausência de um valor dentro de um array|
+| **Array**         | `in`, `notIn`, `contains`, `doesNotContain`                            | Verifica se um valor está em um array (`in`/`notIn`) ou se um array contém um valor (`contains`/`doesNotContain`)|
 
 > Operadores que suportam `value` como lista: `in`, `notIn`, `contains`, `doesNotContain`
 
@@ -156,7 +156,7 @@ Verifica se a propriedade `status` existe e contém pelo menos 1 item:
       "fact": "requestData",
       "path": "$.body.status.length",
       "value": 1,
-      "operator": "greaterThan",
+      "operator": "greaterThanInclusive",
       "description": "Status diferente de nulo"
     }
   ]

--- a/docs/quoti-databases/webhooks.md
+++ b/docs/quoti-databases/webhooks.md
@@ -56,7 +56,115 @@ Você pode cadastrar um novo webhook através do botão “+ Novo”
         - `returnBeforeData` - Campo booleano (com valor true ou false) que determina se a plataforma deve incluir a informação de ‘beforeData’ no corpo da chamada do webhook para eventos de atualização. ‘beforeData’ representa os dados na tabela antes da finalização da edição do registro em andamento.
         - `returnAfterData` - Campo booleano (com valor true ou false) que determina se a plataforma deve incluir a informação de ‘afterData’ no corpo da chamada do webhook para eventos de atualização. ‘afterData’ representa os dados na tabela após a finalização da edição do registro que acabou de ser feita - neste caso, apenas nos eventos de ‘afterUpdate’ este campo estará com os dados definidos.
 
-# Caso de teste
+### Operadores disponíveis
+
+| Tipo         | Operador            | Descrição                                                                 |
+|--------------|---------------------|---------------------------------------------------------------------------|
+| **Booleano** | `all`, `any`, `not` | Controlam a lógica de múltiplas condições                                 |
+| **String/Número** | `equal`, `notEqual`     | Igualdade ou diferença exata (`===` / `!==`)                             |
+| **Numérico** | `lessThan`, `lessThanInclusive`, `greaterThan`, `greaterThanInclusive` | Comparações numéricas diretas                                             |
+| **Array**    | `in`, `notIn`       | Verifica se o valor do fact está ou não em um array                      |
+|              | `contains`, `doesNotContain` | Verifica se um array do fact contém ou não o valor especificado          |
+
+> Operadores que suportam `value` como lista: `in`, `notIn`, `contains`, `doesNotContain`
+
+> ℹ️ Para detalhes completos sobre sintaxe, operadores e exemplos de uso, consulte a [documentação da biblioteca](https://www.npmjs.com/package/json-rules-engine).
+
+## Exemplos de Webhooks
+
+### Exemplo 1 – Webhook somente para categorias específicas
+
+Dispara apenas se o `categoryId` enviado estiver em uma lista predefinida (ex: manutenção de ATM e validadores):
+
+**Configurações:**
+
+```json
+{
+  "asyncHook": true,
+  "returnAfterData": false,
+  "returnBeforeData": false
+}
+```
+
+**Condições:**
+
+```json
+{
+  "all": [
+    {
+      "fact": "requestData",
+      "path": "$.body.categoryId",
+      "value": [
+        100004, 100015, 100016, 100019, 100031,
+        100032, 100033, 100034, 100035, 100036,
+        100037, 100038, 100039, 100040, 100041
+      ],
+      "operator": "in",
+      "description": "Apenas ticket manutenção de ATM e validadores"
+    }
+  ]
+}
+```
+
+---
+
+### Exemplo 2 – Webhook ignorando chats e CCO
+
+Executa o webhook apenas quando o (`ticketTypeId`) **não** corresponder a determinados valores específicos:
+
+> 💡 Como mostrado na imagem abaixo, o conteúdo retornado na chave after deve ser referenciado como dataAfterEvent na condição. Logo, o fact correto a ser utilizado será "dataAfterEvent"
+
+![Exemplo dataAfterEvent](https://firebasestorage.googleapis.com/v0/b/beyond-quoti.appspot.com/o/beyond%2F2025%2F06%2F64b5a783ab971960a240d5155c94a645.png?alt=media&token=c2f158f1-3b95-4947-b6f4-005b242ade9b)
+
+**Configurações:**
+
+```json
+{
+  "attributes": ["ticketTypeId"],
+  "returnAfterData": true,
+  "returnBeforeData": false
+}
+```
+
+**Condições:**
+
+```json
+{
+  "all": [
+    {
+      "fact": "dataAfterEvent",
+      "path": "$.ticketTypeId",
+      "value": [3, 11],
+      "operator": "notIn",
+      "description": "Chamados diferentes de chats e CCO"
+    }
+  ]
+}
+```
+
+---
+
+### Exemplo 3 – Webhook só dispara se `status` não for nulo
+
+Verifica se a propriedade `status` existe e contém pelo menos 1 item:
+
+**Condições:**
+
+```json
+{
+  "all": [
+    {
+      "fact": "requestData",
+      "path": "$.body.status.length",
+      "value": 1,
+      "operator": "greaterThan",
+      "description": "Status diferente de nulo"
+    }
+  ]
+}
+```
+
+## Caso de teste
 
 Vamos criar um webhook de afterCreate em uma tabela e ver como ele é chamado!
 

--- a/docs/quoti-databases/webhooks.md
+++ b/docs/quoti-databases/webhooks.md
@@ -58,13 +58,12 @@ Você pode cadastrar um novo webhook através do botão “+ Novo”
 
 ### Operadores disponíveis
 
-| Tipo         | Operador            | Descrição                                                                 |
-|--------------|---------------------|---------------------------------------------------------------------------|
-| **Booleano** | `all`, `any`, `not` | Controlam a lógica de múltiplas condições                                 |
-| **String/Número** | `equal`, `notEqual`     | Igualdade ou diferença exata (`===` / `!==`)                             |
-| **Numérico** | `lessThan`, `lessThanInclusive`, `greaterThan`, `greaterThanInclusive` | Comparações numéricas diretas                                             |
-| **Array**    | `in`, `notIn`       | Verifica se o valor do fact está ou não em um array                      |
-|              | `contains`, `doesNotContain` | Verifica se um array do fact contém ou não o valor especificado          |
+| Tipo              | Operador                                                               | Descrição                                                     |
+|-------------------|------------------------------------------------------------------------|---------------------------------------------------------------|
+| **Booleano**      | `all`, `any`, `not`                                                    | Controlam a lógica de múltiplas                               |
+| **String/Número** | `equal`, `notEqual`                                                    | Igualdade ou diferença exata (`===` / `!==`)                  |
+| **Numérico**      | `lessThan`, `lessThanInclusive`, `greaterThan`, `greaterThanInclusive` | Comparações numéricas diretas                                 |
+| **Array**         | `in`, `notIn`, `contains`, `doesNotContain`                            | Verifica a presença ou ausência de um valor dentro de um array|
 
 > Operadores que suportam `value` como lista: `in`, `notIn`, `contains`, `doesNotContain`
 


### PR DESCRIPTION
…notes
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhances Quoti webhook documentation with operator details and examples in `webhooks.md`.
> 
>   - **Documentation Enhancements**:
>     - Added a section on available operators for webhook conditions in `webhooks.md`.
>     - Included three detailed examples of webhook configurations and conditions in `webhooks.md`.
>   - **Operators**:
>     - Described operators for Boolean, String/Number, Numeric, and Array types.
>     - Mentioned operators supporting `value` as a list: `in`, `notIn`, `contains`, `doesNotContain`.
>   - **Examples**:
>     - Example 1: Webhook for specific categories using `categoryId`.
>     - Example 2: Webhook ignoring specific `ticketTypeId` values.
>     - Example 3: Webhook triggering if `status` is not null.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=byndcloud%2Fquoti-docs&utm_source=github&utm_medium=referral)<sup> for d05fcd44cc51e3454bc5a8f69bf24a3c2fef9596. You can [customize](https://app.ellipsis.dev/byndcloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->